### PR TITLE
Update CardBrowser.java

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -171,7 +171,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private static final int EDIT_CARD = 0;
     private static final int ADD_NOTE = 1;
     private static final int PREVIEW_CARDS = 2;
-
+    private static int cnt = 1;
     private static final int DEFAULT_FONT_SIZE_RATIO = 100;
     // Should match order of R.array.card_browser_order_labels
     public static final int CARD_ORDER_NONE = 0;
@@ -1738,7 +1738,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
      */
     @VisibleForTesting
     @CheckResult
-    static String formatQAInternal(String txt, boolean showFileNames) {
+     static String formatQAInternal(String txt, boolean showFileNames) {
         /* Strips all formatting from the string txt for use in displaying question/answer in browser */
         String s = txt;
         s = s.replaceAll("<!--.*?-->", "");
@@ -1746,9 +1746,15 @@ public class CardBrowser extends NavigationDrawerActivity implements
         s = s.replace("<br />", " ");
         s = s.replace("<div>", " ");
         s = s.replace("\n", " ");
-        s = showFileNames ? Utils.stripSoundMedia(s) : Utils.stripSoundMedia(s, " ");
         s = s.replaceAll("\\[\\[type:[^]]+]]", "");
-        s = showFileNames ? Utils.stripHTMLMedia(s) : Utils.stripHTMLMedia(s, " ");
+        if(showFileNames){
+            s=Utils.stripHTMLMedia(s);
+            s=Utils.stripSoundMedia(s);
+        }else{
+            s=Utils.stripHTMLMedia(s, "file"+cnt);
+            s=Utils.stripSoundMedia(s, "file"+cnt);
+            cnt++;
+        }
         s = s.trim();
         return s;
     }


### PR DESCRIPTION

## Purpose / Description
Audible cards are shown as free space in Card browser, it looks like empty card.

## Fixes
Fix the issue: https://github.com/ankidroid/Anki-Android/issues/8871

## Approach
In the cardbrowser, the displayed text of audible file card was replaced by "", so it looks the same as empty. So we just need to use something to replace "".

## How Has This Been Tested?

![image](https://user-images.githubusercontent.com/50438846/119222675-0d3b2d00-bb28-11eb-9552-1145c4099e53.png)

before:
![image](https://user-images.githubusercontent.com/50438846/119222690-2d6aec00-bb28-11eb-99a4-34e279857131.png)

after:
![image](https://user-images.githubusercontent.com/50438846/119222662-fbf22080-bb27-11eb-878d-678cecc2bf0b.png)

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)